### PR TITLE
359 😛

### DIFF
--- a/history.js
+++ b/history.js
@@ -71,3 +71,5 @@ x=y=a=[];for(C of O.value)++x,C<" "?x=!++y:C>" "&&a.push({x,y,C,w:"#"==C,u:0,v:0
 _=a=[];for(C of O.value)_++,C>" "&&a.push({x:_%80,y:_/80|0,C,w:"#"==C,u:0,v:0});M=o=>a.map(p=>{p.t=.1;p.s=0;o||(p.D=p.w);a.map(q=>(g=Math.hypot(e=p.x-q.x,f=p.y-q.y)/2-1)<0?o?(g/=p.D,p.t+=(f*(z=3-p.D-q.D)+p.v-q.v)*g,p.s+=(e*z+p.u-q.u)*g):p.D+=g*g:1)});setInterval`M(c.width^=M());for(p of a)with(p)c.getContext("2d").fillText(C,3*x,5*y),w||(y+=v+=t/4,x+=u+=s/2)`
 
 _=a=[];for(C of O.value)_++,C>" "&&a.push({x:_%80,y:_/80|0,C,w:"$">C,u:0,v:0});M=o=>a.map(p=>{p.t=.1;p.s=0;o||(p.D=p.w);a.map(q=>(g=Math.hypot(e=p.x-q.x,f=p.y-q.y)/2-1)<0?o?(g/=p.D,p.t+=(f*(z=3-p.D-q.D)+p.v-q.v)*g,p.s+=(e*z+p.u-q.u)*g):p.D+=g*g:1)});setInterval`M(c.width^=M());for(p of a)with(p)c.getContext("2d").fillText(C,3*x,5*y),w||(y+=v+=t/4,x+=u+=s/2)`
+
+_=a=[];for(C of O.value)_++,C>" "&&a.push({x:_%128,y:_>>7,C,w:"$">C,u:0,v:0});M=o=>a.map(p=>{p.t=.1;p.s=0;o||(p.D=p.w);a.map(q=>(g=Math.hypot(e=p.x-q.x,f=p.y-q.y)/2-1)<0?o?(g/=p.D,p.t+=(f*(z=3-p.D-q.D)+p.v-q.v)*g,p.s+=(e*z+p.u-q.u)*g):p.D+=g*g:1)});setInterval`M(c.width^=M());for(p of a)with(p)c.getContext("2d").fillText(C,3*x,5*y),w||(y+=v+=t/4,x+=u+=s/2)`

--- a/index.html
+++ b/index.html
@@ -1,39 +1,38 @@
-<!doctype html>
+<doctype html>
 <tt>
 <h2>MiniFluid</h2>
 <p>A micro fluid simulation inspired by <a href="https://www.ioccc.org/2012/endoh1/hint.html">endoh1.c</a> and its TS port <a href="https://github.com/phiresky/endoh1-ts">endoh1-ts</a>
 <p>Golfed by <a href=https://twitter.com/xem rel=noopener>xem</a>, <a href=https://twitter.com/p01 rel=noopener>p01</a>, <a href=https://twitter.com/aemkei rel=noopener>Aemkei</a>, <a href=https://twitter.com/IrratixMusic rel=noopener>Irratix</a>, <a href=https://twitter.com/RReverser rel=noopener>RReverser</a>
-<p><canvas id=c style="width:400px;height:250px"></canvas>
+<p><canvas id=c style="height:300px"></canvas>
 <p>Input:<p>
-<textarea id=O cols=80 rows=27>
-                                                                               
-                                                                               
-                                                                               
-#  include&lt;stdio.h>//  .IOCCC                                         Fluid-  #
-#  include &lt;unistd.h>  //2012                                         _Sim!_  #
-#  include&lt;complex.h>  //||||                     ,____.              IOCCC-  #
-#  define              h for(                     x=011;              2012/*  #
-#  */-1>x              ++;)b[                     x]//-'              winner  #
-#  define              f(p,e)                                         for(/*  #
-#  */p=a;              e,p&lt;r;                                        p+=5)//  #
-#  define              z(e,i)                                        f(p,p/*  #
-## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  &lt;(x=1-      w))p[i]+=w*/// ##
-   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    int x,y;char b/* ##
-## */[6856]='\x1b[2J'  '\x1b'  '[1;1H     ', *o=  b, *t;   int main   (){/** ##
-## */for(              ;0&lt;(x=  getc (     stdin)  );)w=x  >10?32&lt;     x?4[/* ##
-## */*r++              =w,r]=  w+1,*r     =r[5]=  x==35,  r+=9:0      ,w-I/* ##
-## */:(x=              w+2);;  for(;;     puts(o  ),o=b+  4){z(p      [1]*/* ##
-## */9,2)              w;z(G,  3)(d*(     3-p[2]  -q[2])  *P+p[4      ]*V-/* ##
-## */q[4]              *V)/p[  2];h=0     ;f(p,(  t=b+10  +(x=*p      *I)+/* ##
-## */80*(              y=*p/2  ),*p+=p    [4]+=p  [3]/10  *!p[1])     )x=0/* ##
-## */ &lt;=x              &&x&lt;79   &&0&lt;=y&&y&lt;23?1[1  [*t|=8   ,t]|=4,t+=80]=1/* ##
-## */, *t              |=2:0;    h=' '`-.|//,\\'  '|\\_'    '\\/\x23\n'[x/** ##
-## */%80-              9?x[b]      :16];;usleep(  12321)      ;}return 0;}/* ##
-####                                                                       ####
-###############################################################################
-**###########################################################################*/
+<textarea id=O cols=128 rows=27>#                                                                             #                                                
+#                                                                             #                                                
+#                                                                             #                                                
+#  include<stdio.h>//  .IOCCC                                         Fluid-  #                                                
+#  include <unistd.h>  //2012                                          _Sim_  #                                                
+#  include<complex.h>  //||||                     ,____.              IOCCC-  #                                                
+#  define              h for(                     x=011;              2012/*  #                                                
+#  */-1>x              ++;)b[                     x]//-'              winner  #                                                
+#  define              f(p,e)                                         for(/*  #                                                
+#  */p=a;              e,p<r;                                        p+=5)//  #                                                
+#  define              z(e,i)                                        f(p,p/*  #                                                
+## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  <(x=1-      w))p[i]+=w*/// ##                                                
+   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    int x,y;char b/* ##                                                
+## */[6856]="\x1b[2J"  "\x1b"  "[1;1H     ", *o=  b, *t;   int main   (){/** ##                                                
+## */for(              ;0<(x=  getc (     stdin)  );)w=x  >10?32<     x?4[/* ##                                                
+## */*r++              =w,r]=  w+1,*r     =r[5]=  x==35,  r+=9:0      ,w-I/* ##                                                
+## */:(x=              w+2);;  for(;;     puts(o  ),o=b+  4){z(p      [1]*/* ##                                                
+## */9,2)              w;z(G,  3)(d*(     3-p[2]  -q[2])  *P+p[4      ]*V-/* ##                                                
+## */q[4]              *V)/p[  2];h=0     ;f(p,(  t=b+10  +(x=*p      *I)+/* ##                                                
+## */80*(              y=*p/2  ),*p+=p    [4]+=p  [3]/10  *p[1])      )x=0/* ##                                                
+## */ <=x              &&x<79   &&0<=y&&y<23?1[1  [*t|=8   ,t]|=4,t+=80]=1/* ##                                                
+## */, *t              |=2:0;    h=" '`-.|//,\\"  "|\\_"    "\\/\x23\n"[x/** ##                                                
+## */%80-              9?x[b]      :16];;usleep(  12321)      ;}return 0;}/* ##                                                
+####                                                                       ####                                                
+###############################################################################                                                
+**###########################################################################*/                                                
 </textarea>
 
 <script>
-_=a=[];for(C of O.value)_++,C>" "&&a.push({x:_%80,y:_/80|0,C,w:"$">C,u:0,v:0});M=o=>a.map(p=>{p.t=.1;p.s=0;o||(p.D=p.w);a.map(q=>(g=Math.hypot(e=p.x-q.x,f=p.y-q.y)/2-1)<0?o?(g/=p.D,p.t+=(f*(z=3-p.D-q.D)+p.v-q.v)*g,p.s+=(e*z+p.u-q.u)*g):p.D+=g*g:1)});setInterval`M(c.width^=M());for(p of a)with(p)c.getContext("2d").fillText(C,3*x,5*y),w||(y+=v+=t/4,x+=u+=s/2)`
+_=a=[];for(C of O.value)_++,C>" "&&a.push({x:_%128,y:_>>7,C,w:"$">C,u:0,v:0});M=o=>a.map(p=>{p.t=.1;p.s=0;o||(p.D=p.w);a.map(q=>(g=Math.hypot(e=p.x-q.x,f=p.y-q.y)/2-1)<0?o?(g/=p.D,p.t+=(f*(z=3-p.D-q.D)+p.v-q.v)*g,p.s+=(e*z+p.u-q.u)*g):p.D+=g*g:1)});setInterval`M(c.width^=M());for(p of a)with(p)c.getContext("2d").fillText(C,3*x,5*y),w||(y+=v+=t/4,x+=u+=s/2)`
 </script>


### PR DESCRIPTION
If we can't use `x:_%80;y:_\80` then let's use `x:_%128;y:_>>7` and pad the textarea instead.

Once we finalize the quine, we can use 64 characters wide to save one extra byte by using `x:_%64,y:y>>6`